### PR TITLE
Verify website with Mastodon

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
         </li>
         <li>
           <i class="fab fa-mastodon"></i>
-          <a href="https://mastodon.social/@micahflee">@micahflee@mastodon.social</a>
+          <a rel="me" href="https://mastodon.social/@micahflee">@micahflee@mastodon.social</a>
         </li>
         <li>
           <i class="fas fa-rss"></i>


### PR DESCRIPTION
Hello, I realized that your website hasn't been verified, since it looks like this:

![image](https://user-images.githubusercontent.com/50847364/95677740-9901d980-0b95-11eb-95d3-b6ef4a947fe1.png)

After merging this MR, going to `Preferences > Profile > Profile metadata`, removing the website and finally readding it, the website should be green.